### PR TITLE
Allow shell executor to inherit environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Configuration uses TOML format described here: https://github.com/toml-lang/toml
       executor = "docker"
       builds_dir = ""
       shell_script = ""
+      clean_environment = false
       environment = ["ENV=value", "LC_ALL=en_US.UTF-8"]
     ```
 
@@ -128,6 +129,8 @@ Configuration uses TOML format described here: https://github.com/toml-lang/toml
     * `limit` - limit how many jobs can be handled concurrently by this token. 0 simply means don't limit.
     * `executor` - select how project should be built. See below.
     * `builds_dir` - directory where builds will be stored in context of selected executor (Locally, Docker, SSH)
+    * `clean_environment` - do not inherit any environment variables from the multi-runner process
+    * `environment` - append or overwrite environment variables
 
 1. The EXECUTORS:
 

--- a/commands/setup.go
+++ b/commands/setup.go
@@ -119,10 +119,11 @@ func runSetup(c *cli.Context) {
 	}
 
 	runner_config := common.RunnerConfig{
-		URL:      url,
-		Name:     description,
-		Token:    result.Token,
-		Executor: c.String("executor"),
+		URL:              url,
+		Name:             description,
+		Token:            result.Token,
+		Executor:         c.String("executor"),
+		CleanEnvironment: c.Bool("clean_environment"),
 	}
 
 	askExecutor(bio, &runner_config.Executor)
@@ -195,6 +196,11 @@ var (
 				Value:  "",
 				Usage:  "Select executor, eg. shell, docker, etc.",
 				EnvVar: "RUNNER_EXECUTOR",
+			},
+			cli.BoolFlag{
+				Name:   "clean_environment",
+				Usage:  "do not inherit any environment vars from parent process (default: false)",
+				EnvVar: "RUNNER_CLEANENVIRONMENT",
 			},
 		},
 	}

--- a/common/config.go
+++ b/common/config.go
@@ -41,7 +41,8 @@ type RunnerConfig struct {
 	Executor  string `toml:"executor" json:"executor"`
 	BuildsDir string `toml:"builds_dir" json:"builds_dir"`
 
-	Environment []string `toml:"environment" json:"environment"`
+	CleanEnvironment  bool     `toml:"clean_environment" json:"clean_environment"`
+	Environment       []string `toml:"environment" json:"environment"`
 
 	ShellScript string `toml:"shell_script" json:"shell_script"`
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -8,6 +8,7 @@ root_dir = ""
   limit = 2
   executor = "shell"
   builds_dir = ""
+  clean_environment = false
 
 [[runners]]
   name = "ruby-2.1-docker"

--- a/executors/shell/executor_shell.go
+++ b/executors/shell/executor_shell.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os/exec"
+        "os"
 
 	"github.com/ayufan/gitlab-ci-multi-runner/common"
 	"github.com/ayufan/gitlab-ci-multi-runner/executors"
@@ -41,8 +42,13 @@ func (s *ShellExecutor) Start() error {
 
 	helpers.SetProcessGroup(s.cmd)
 
+	// Inherit environment from current process
+	if ! s.Config.CleanEnvironment {
+	  s.cmd.Env = os.Environ()
+        }
+
 	// Fill process environment variables
-	s.cmd.Env = append(s.Build.GetEnv(), s.Config.Environment...)
+	s.cmd.Env = append(s.cmd.Env, append(s.Build.GetEnv(), s.Config.Environment...)...)
 	s.cmd.Stdin = bytes.NewReader(s.BuildScript)
 	s.cmd.Stdout = s.BuildLog
 	s.cmd.Stderr = s.BuildLog


### PR DESCRIPTION
This fixes issue 'PATH issue with Shell executor #1'

In the config.toml you are able to specify a bool to inherit all the environment vars of the running process. Defaults to false to conform to current behaviour.