### PR TITLE
Waiting for services to be up and running (docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Configuration uses TOML format described here: https://github.com/toml-lang/toml
       privileged = false
       disable_cache = false
       disable_pull = false
+      disable_wait = false
       cache_dir = ""
       registry = ""
       volumes = ["/data", "/home/project/cache"]
@@ -166,6 +167,7 @@ Configuration uses TOML format described here: https://github.com/toml-lang/toml
     * `privileged` - make container run in Privileged mode (insecure)
     * `disable_cache` - disable automatic
     * `disable_pull` - disable automatic image pulling if not found
+    * `disable_wait` - disable automatic wait for services to be up and running
     * `cache_dir` - specify where Docker caches should be stored (this can be absolute or relative to current working directory)
     * `registry` - specify custom Docker registry to be used
     * `volumes` - specify additional volumes that should be cached

--- a/common/config.go
+++ b/common/config.go
@@ -19,6 +19,7 @@ type DockerConfig struct {
 	Privileged   bool     `toml:"privileged" json:"privileged"`
 	DisableCache bool     `toml:"disable_cache" json:"disable_cache"`
 	DisablePull  bool     `toml:"disable_pull" json:"disable_pull"`
+	DisableWait  bool     `toml:"disable_wait" json:"disable_wait"`
 	Volumes      []string `toml:"volumes" json:"volumes"`
 	CacheDir     string   `toml:"cache_dir" json:"cache_dir"`
 	Registry     string   `toml:"registry" json:"registry"`


### PR DESCRIPTION
Sometime when executing build commands, services container can be not
completely started leading to errors.
This issue is addressed here by injecting the "aanand/wait" docker
image after each service start.

See also https://github.com/ayufan/gitlab-ci-multi-runner/issues/9