### PR TITLE
Remove WorkingDirectory from Systemd service

### DIFF
--- a/packaging/systemd/root/lib/systemd/system/gitlab-ci-multi-runner.service
+++ b/packaging/systemd/root/lib/systemd/system/gitlab-ci-multi-runner.service
@@ -13,7 +13,6 @@ After=syslog.target network.target
 Type=simple
 User=gitlab_ci_multi_runner
 Group=gitlab_ci_multi_runner
-WorkingDirectory=/home/gitlab_ci_multi_runner
 ExecStart=/usr/bin/gitlab-ci-multi-runner run
 
 # if we crash, restart


### PR DESCRIPTION
By default systemd will use the respective user's home directory if run as user.
see: http://man7.org/linux/man-pages/man5/systemd.exec.5.html#OPTIONS

Also useful if the user has setup a different home directory for `gitlab_ci_multi_runner` other than `/home/gitlab_ci_multi_runner`, for example `/var/lib/gitlab-ci-multi-runner`