### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/install/linux-repository.md
+++ b/docs/install/linux-repository.md
@@ -12,7 +12,7 @@ Add GitLab's official repository via apt-get or yum:
 
 ```bash
 # For Debian/Ubuntu
-curl https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.deb | sudo bash
+curl https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.deb.sh | sudo bash
 
 # For CentOS
 curl https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.rpm | sudo bash


### PR DESCRIPTION
curl command for gitlab-ci-multi-runner was referencing bad url