### PR TITLE
Add missing Git in alpine version

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -1,6 +1,11 @@
 FROM alpine
 
-RUN apk add --update bash wget ca-certificates openssl
+RUN apk add --update \
+		bash \
+		ca-certificates \
+		git \
+		openssl \
+		wget
 
 RUN wget -O /tmp/glibc.apk "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
     apk add --allow-untrusted /tmp/glibc.apk && \


### PR DESCRIPTION
With the ```gitlab-runner:alpine``` version, this error is thrown when a build is runs.

```
gitlab-ci-multi-runner 1.0.4 (014aa8c)
Using Shell executor...
Running on 084238b313b4...
Cloning repository...
bash: line 34: git: command not found

ERROR: Build failed with: exit status 1
```