### PR TITLE
Adding centos dockerfile for gitlab-runner

### DIFF
--- a/dockerfiles/centos/Dockerfile
+++ b/dockerfiles/centos/Dockerfile
@@ -17,6 +17,10 @@ RUN curl -s https://packages.gitlab.com/install/repositories/runner/gitlab-ci-mu
 ADD entrypoint /
 RUN chmod +x /entrypoint
 
+# Update certs
+RUN /usr/bin/update-ca-trust enable
+RUN /usr/bin/update-ca-trust
+
 VOLUME ["/etc/gitlab-runner", "/home/gitlab-runner"]
 ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint"]
 CMD ["run", "--user=gitlab-runner", "--working-directory=/home/gitlab-runner"]

--- a/dockerfiles/centos/Dockerfile
+++ b/dockerfiles/centos/Dockerfile
@@ -1,0 +1,22 @@
+FROM centos:7
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/bin/dumb-init
+RUN chmod +x /usr/bin/dumb-init
+
+RUN yum update -y && \
+    yum install -y ca-certificates wget vim nano git
+
+RUN curl -s https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.rpm.sh | bash && \
+    yum install -y gitlab-ci-multi-runner && \
+    wget https://github.com/docker/machine/releases/download/v0.8.2/docker-machine-Linux-x86_64 -O /usr/bin/docker-machine && \
+    chmod +x /usr/bin/docker-machine && \
+    mkdir -p /etc/gitlab-runner/certs && \
+    chmod -R 700 /etc/gitlab-runner
+
+
+ADD entrypoint /
+RUN chmod +x /entrypoint
+
+VOLUME ["/etc/gitlab-runner", "/home/gitlab-runner"]
+ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint"]
+CMD ["run", "--user=gitlab-runner", "--working-directory=/home/gitlab-runner"]

--- a/dockerfiles/centos/README.md
+++ b/dockerfiles/centos/README.md
@@ -1,0 +1,1 @@
+`gitlab/gitlab-runner:latest` is image that can be used to run GitLab Runner in container.

--- a/dockerfiles/centos/entrypoint
+++ b/dockerfiles/centos/entrypoint
@@ -10,6 +10,8 @@ LOCAL_CA_PATH="/etc/ssl/certs/ca-bundle.crt"
 update_ca() {
   echo "Updating CA certificates..."
   cp "${CA_CERTIFICATES_PATH}" "${LOCAL_CA_PATH}"
+  /usr/bin/update-ca-trust enable > /dev/null
+  /usr/bin/update-ca-trust > /dev/bull
   update-ca-certificates --fresh >/dev/null
 }
 

--- a/dockerfiles/centos/entrypoint
+++ b/dockerfiles/centos/entrypoint
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# gitlab-ci-multi-runner data directory
+DATA_DIR="/etc/gitlab-runner"
+CONFIG_FILE=${CONFIG_FILE:-$DATA_DIR/config.toml}
+# custom certificate authority path
+CA_CERTIFICATES_PATH=${CA_CERTIFICATES_PATH:-$DATA_DIR/certs/ca.crt}
+LOCAL_CA_PATH="/etc/ssl/certs/ca-bundle.crt"
+
+update_ca() {
+  echo "Updating CA certificates..."
+  cp "${CA_CERTIFICATES_PATH}" "${LOCAL_CA_PATH}"
+  update-ca-certificates --fresh >/dev/null
+}
+
+if [ -f "${CA_CERTIFICATES_PATH}" ]; then
+  # update the ca if the custom ca is different than the current
+  cmp --silent "${CA_CERTIFICATES_PATH}" "${LOCAL_CA_PATH}" || update_ca
+fi
+
+# launch gitlab-ci-multi-runner passing all arguments
+exec gitlab-ci-multi-runner "$@"


### PR DESCRIPTION
Dealing with SSL certs on a CentOS based infrastructure is a pain. Here's an example dockerfile for a centos based runner
