### PR TITLE
Don't override container's `entrypoint`

### DIFF
--- a/executors/kubernetes/executor_kubernetes.go
+++ b/executors/kubernetes/executor_kubernetes.go
@@ -128,7 +128,7 @@ func (s *executor) buildContainer(name, image string, limits api.ResourceList, c
 	return api.Container{
 		Name:    name,
 		Image:   image,
-		Command: command,
+		Args:    command,
 		Env:     buildVariables(s.Build.GetAllVariables().PublicOrInternal()),
 		Resources: api.ResourceRequirements{
 			Limits: limits,


### PR DESCRIPTION
Bring the Kubernetes executor [into line with the Docker executor](https://docs.gitlab.com/runner/executors/docker.html#the-entrypoint), which never overrides `entrypoint`, but only `cmd`. In Kubernetes [this is done using the `args` parameter instead of the `command` parameter](https://github.com/kubernetes/kubernetes/issues/8235).
