### PR TITLE
Added link to Kubernetes executor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Supported systems by different shells:
 * [Help me select executor](docs/executors/README.md#imnotsure)
 * [Shell](docs/executors/shell.md)
 * [Docker and Docker-SSH](docs/executors/docker.md)
+* [Kubernetes](docs/executors/kubernetes.md)
 * [Parallels](docs/executors/parallels.md)
 * [VirtualBox](docs/executors/virtualbox.md)
 * [SSH](docs/executors/ssh.md)


### PR DESCRIPTION
The documentation already existed, but there was no mentioning of it in the main Readme.md